### PR TITLE
Preliminary multiturn support

### DIFF
--- a/tests/verl/utils/dataset/test_multiturn.py
+++ b/tests/verl/utils/dataset/test_multiturn.py
@@ -1,0 +1,68 @@
+from verl.utils.dataset.rl_dataset import (
+    RLHFDataset,
+    collate_fn,
+    MultiTurnPromptManager,
+)
+from torchdata.stateful_dataloader import StatefulDataLoader
+from verl import DataProto
+from verl.utils import hf_tokenizer
+import tempfile
+import pandas as pd
+
+multiturn_prompt = [
+    dict(role="user", content="What are you doing?"),
+    dict(role="user", content="Any luck?"),
+]
+
+mock_data = [dict(prompt=multiturn_prompt)]
+# Save it to a temporary parquet file
+
+with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+    pd.DataFrame(mock_data).to_parquet(f.name)
+    f.flush()
+    print("Saving mock data to", f.name)
+
+    tokenizer = hf_tokenizer("Qwen/Qwen2.5-3B-Instruct")
+    dataset = RLHFDataset(
+        parquet_files=f.name,
+        tokenizer=tokenizer,
+        processor=None,
+        prompt_key="prompt",
+        # image_key=self.config.data.get('image_key', 'images'),
+        max_prompt_length=3072,
+        filter_prompts=True,
+        return_raw_chat=True,
+        # truncation=
+        # filter_overlong_prompts=self.config.data.filter_overlong_prompts
+    )
+
+    dataloader = StatefulDataLoader(
+        dataset=dataset,
+        batch_size=1,  # hardcode the 2x
+        num_workers=1,
+        drop_last=True,
+        collate_fn=collate_fn,
+        # sampler=sampler
+    )
+
+    prompt_manager = MultiTurnPromptManager()
+
+    batch_dict = next(iter(dataloader))
+    batch: DataProto = DataProto.from_dict(batch_dict)
+    old_prompt = batch_dict["input_ids"][0]
+
+    data_indices = batch.batch["data_index"]
+
+    # example_multi = copy.deepcopy(dataset.dataframe.iloc[0].to_dict())
+    newdata = dataset.try_create_multiturn_data(
+        0, "1 or 2", batch_dict["raw_prompt"][0], batch_dict["remaining_prompt"][0]
+    )
+    row_processed = dataset.process_row(0, newdata)
+
+    prompt_manager.update_multiturn_prompts([row_processed])
+    prompt_manager.replace_prompts_inplace(batch_dict)
+
+    new_prompt = batch_dict["input_ids"][0]
+
+    print("OLD PROMPT:", tokenizer.decode(old_prompt, skip_special_tokens=True), sep="\n")
+    print("NEW PROMPT:", tokenizer.decode(new_prompt, skip_special_tokens=True), sep="\n")

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -229,6 +229,124 @@ def _timer(name: str, timing_raw: Dict[str, float]):
     timing_raw[name] += timer.last
 
 
+# NOTE(yuxiang)
+# I need a multiturn queue or something that maintains (1) prompts that need further generation
+# and (2) prompts whose generation are delayed due to multiturn prompts.
+# It needs to implement a method that replace parts of the input batch_dict with multiturn prompts.
+from collections import deque
+from typing import Any
+
+@dataclass
+class MultiTurnPromptManager:
+    """
+    Maintains:
+        1) A queue of multi-turn prompts that still need to be continued in future batches.
+        2) A cache of single-turn prompts that can be re-used for partially filling the batch.
+    """
+    # For incomplete multi-turn prompts from previous steps
+    multiturn_queue: deque[dict] = field(default_factory=deque)
+    # For storing single-turn prompts that have been replaced in prior steps
+    singleturn_cache: deque[dict] = field(default_factory=deque)
+
+    def replace_prompts(self, batch_dict: dict[str, list]) -> dict[str, list]:
+        """
+        1) If we have N multi-turn prompts in the queue, then we replace the LAST min(N, batch_size)
+           items in `batch_dict` with the first min(N, batch_size) items from `multiturn_queue`.
+           - Also, we take those replaced batch items and store them in `singleturn_cache`.
+        2) For the remaining front of the batch, we replace up to that many from `singleturn_cache`.
+           - Again, replaced original items are stored back into `singleturn_cache`.
+        3) Return the modified `batch_dict`.
+
+        NOTE: This assumes `batch_dict` has lists or tensors of the same length (batch_size).
+              If they are PyTorch tensors, you should convert them to lists or carefully slice them.
+        """
+
+        batch_size = len(batch_dict["input_ids"])
+        # --------------
+        # Step 1: Replace the LAST K = min(len(multiturn_queue), batch_size) items with multi-turn prompts
+        # --------------
+
+        K = min(len(self.multiturn_queue), batch_size)
+        # We'll operate on indices from (batch_size - K) to (batch_size-1)
+        for idx_offset in range(K):
+            idx = batch_size - 1 - idx_offset  # from the end going backwards
+
+            # Pop an item from multi-turn queue
+            multiturn_item = self.multiturn_queue.popleft()
+
+            # Save original batch item to single-turn cache
+            original_item = self._extract_batch_item(batch_dict, idx)
+            self.singleturn_cache.append(original_item)
+
+            # Insert the multi-turn item into the batch
+            self._put_batch_item(batch_dict, idx, multiturn_item)
+
+        # --------------
+        # Step 2: For the FRONT M-K items, try replacing them from singleturn_cache
+        # --------------
+
+        remaining_front = batch_size - K
+        L = min(len(self.singleturn_cache), remaining_front)
+
+        # Replace the FIRST L items in the batch
+        for idx in range(L):
+            singleturn_item = self.singleturn_cache.popleft()
+
+            # Save original batch item to single-turn cache
+            original_item = self._extract_batch_item(batch_dict, idx)
+            self.singleturn_cache.append(original_item)
+
+            # Insert the single-turn item into the batch
+            self._put_batch_item(batch_dict, idx, singleturn_item)
+
+        # The middle portion (from L to remaining_front) remains untouched
+        # The last portion (already replaced with multi-turn) remains as is.
+
+        return batch_dict
+
+    def update_multiturn_prompts(self, new_prompts: list[dict[str, Any]]) -> None:
+        """
+        Append new incomplete multi-turn prompts to the queue for use in future batches.
+        Typically called after generation steps when we identify incomplete dialogues.
+        """
+        for prompt in new_prompts:
+            self.multiturn_queue.append(prompt)
+
+    @staticmethod
+    def _extract_batch_item(batch_dict: dict[str, list], idx: int) -> dict[str, Any]:
+        """
+        Take a snapshot of the 'idx'-th item from each list/tensor in batch_dict.
+        Return it as a dictionary that can be re-injected later.
+        """
+        item = {}
+        for key, val_list in batch_dict.items():
+            if isinstance(val_list, list):
+                item[key] = val_list[idx]
+            else:
+                # If they're Tensors, do slice operation.
+                # For instance: item[key] = val_list[idx].clone()
+                # Here we assume a 1D or ND tensor with batch dimension = 0
+                item[key] = val_list[idx]
+        return item
+
+    @staticmethod
+    def _put_batch_item(batch_dict: dict[str, list], idx: int, item: dict[str, Any]) -> None:
+        """
+        Place the given 'item' into the 'idx'-th position of each list/tensor in batch_dict.
+        """
+        for key, val_list in batch_dict.items():
+            if key in item:
+                if isinstance(val_list, list):
+                    val_list[idx] = item[key]
+                else:
+                    # If they're Tensors, we do an assignment:
+                    # val_list[idx] = item[key]
+                    val_list[idx] = item[key]
+            else:
+                # If 'item' does not have this key, we skip or fill with default
+                pass
+
+
 class RayPPOTrainer(object):
     """
     Note that this trainer runs on the driver process on a single CPU/GPU node.
@@ -248,6 +366,7 @@ class RayPPOTrainer(object):
 
         # assert torch.cuda.is_available(), 'cuda must be available on driver'
 
+        self.multiturn_prompt_manager = MultiTurnPromptManager()
         self.tokenizer = tokenizer
         self.processor = processor
         self.config = config
@@ -424,6 +543,12 @@ class RayPPOTrainer(object):
             drop_last=True,
             collate_fn=collate_fn,
             sampler=sampler)
+
+        # with open("tmp1.pkl", "wb") as f:
+        #     for batch_idx, batch_dict in enumerate(self.train_dataloader):
+        #         import pickle
+        #         pickle.dump(batch_dict, f)
+        #         exit()
 
         self.val_dataset = RLHFDataset(parquet_files=self.config.data.val_files,
                                        tokenizer=self.tokenizer,
@@ -809,6 +934,10 @@ class RayPPOTrainer(object):
             for batch_idx, batch_dict in enumerate(self.train_dataloader):
                 metrics = {}
 
+                # NOTE(yuxiang): replace a subset of prompts with newly generated multiturn prompts
+                # and postpone the replaced prompts to later batches
+                batch_dict = self.multiturn_prompt_manager.replace_prompts(batch_dict)
+
                 batch: DataProto = DataProto.from_single_dict(batch_dict)
                 num_substep_prompt_cumulation += 1
                 num_checked_prompt_per_step += len(batch.batch)
@@ -831,6 +960,9 @@ class RayPPOTrainer(object):
                     # generate a batch
                     with _timer('gen', timing_raw):
                         gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
+                    
+                    # XXX(yuxiang): implement the multiturn enqueue logic here
+                    # self.multiturn_prompt_manager.update_multiturn_prompts(...)
 
                     if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
                         with _timer('gen_max', timing_raw):

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -40,7 +40,7 @@ from verl.trainer.ppo import core_algos
 from verl.trainer.ppo.metric_utils import compute_data_metrics, compute_throughout_metrics, compute_timing_metrics, reduce_metrics
 from verl.utils.seqlen_balancing import get_seqlen_balanced_partitions, log_seqlen_unbalance
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
-from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
+from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn, MultiTurnPromptManager
 from verl.utils.tracking import ValidationGenerationsLogger
 from torch.utils.data import RandomSampler, SequentialSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
@@ -228,125 +228,6 @@ def _timer(name: str, timing_raw: Dict[str, float]):
         yield
     timing_raw[name] += timer.last
 
-
-# NOTE(yuxiang)
-# I need a multiturn queue or something that maintains (1) prompts that need further generation
-# and (2) prompts whose generation are delayed due to multiturn prompts.
-# It needs to implement a method that replace parts of the input batch_dict with multiturn prompts.
-from collections import deque
-from typing import Any
-
-@dataclass
-class MultiTurnPromptManager:
-    """
-    Maintains:
-        1) A queue of multi-turn prompts that still need to be continued in future batches.
-        2) A cache of single-turn prompts that can be re-used for partially filling the batch.
-    """
-    # For incomplete multi-turn prompts from previous steps
-    multiturn_queue: deque[dict] = field(default_factory=deque)
-    # For storing single-turn prompts that have been replaced in prior steps
-    singleturn_cache: deque[dict] = field(default_factory=deque)
-
-    def replace_prompts(self, batch_dict: dict[str, list]) -> dict[str, list]:
-        """
-        1) If we have N multi-turn prompts in the queue, then we replace the LAST min(N, batch_size)
-           items in `batch_dict` with the first min(N, batch_size) items from `multiturn_queue`.
-           - Also, we take those replaced batch items and store them in `singleturn_cache`.
-        2) For the remaining front of the batch, we replace up to that many from `singleturn_cache`.
-           - Again, replaced original items are stored back into `singleturn_cache`.
-        3) Return the modified `batch_dict`.
-
-        NOTE: This assumes `batch_dict` has lists or tensors of the same length (batch_size).
-              If they are PyTorch tensors, you should convert them to lists or carefully slice them.
-        """
-
-        batch_size = len(batch_dict["input_ids"])
-        # --------------
-        # Step 1: Replace the LAST K = min(len(multiturn_queue), batch_size) items with multi-turn prompts
-        # --------------
-
-        K = min(len(self.multiturn_queue), batch_size)
-        # We'll operate on indices from (batch_size - K) to (batch_size-1)
-        for idx_offset in range(K):
-            idx = batch_size - 1 - idx_offset  # from the end going backwards
-
-            # Pop an item from multi-turn queue
-            multiturn_item = self.multiturn_queue.popleft()
-
-            # Save original batch item to single-turn cache
-            original_item = self._extract_batch_item(batch_dict, idx)
-            self.singleturn_cache.append(original_item)
-
-            # Insert the multi-turn item into the batch
-            self._put_batch_item(batch_dict, idx, multiturn_item)
-
-        # --------------
-        # Step 2: For the FRONT M-K items, try replacing them from singleturn_cache
-        # --------------
-
-        remaining_front = batch_size - K
-        L = min(len(self.singleturn_cache), remaining_front)
-
-        # Replace the FIRST L items in the batch
-        for idx in range(L):
-            singleturn_item = self.singleturn_cache.popleft()
-
-            # Save original batch item to single-turn cache
-            original_item = self._extract_batch_item(batch_dict, idx)
-            self.singleturn_cache.append(original_item)
-
-            # Insert the single-turn item into the batch
-            self._put_batch_item(batch_dict, idx, singleturn_item)
-
-        # The middle portion (from L to remaining_front) remains untouched
-        # The last portion (already replaced with multi-turn) remains as is.
-
-        return batch_dict
-
-    def update_multiturn_prompts(self, new_prompts: list[dict[str, Any]]) -> None:
-        """
-        Append new incomplete multi-turn prompts to the queue for use in future batches.
-        Typically called after generation steps when we identify incomplete dialogues.
-        """
-        for prompt in new_prompts:
-            self.multiturn_queue.append(prompt)
-
-    @staticmethod
-    def _extract_batch_item(batch_dict: dict[str, list], idx: int) -> dict[str, Any]:
-        """
-        Take a snapshot of the 'idx'-th item from each list/tensor in batch_dict.
-        Return it as a dictionary that can be re-injected later.
-        """
-        item = {}
-        for key, val_list in batch_dict.items():
-            if isinstance(val_list, list):
-                item[key] = val_list[idx]
-            else:
-                # If they're Tensors, do slice operation.
-                # For instance: item[key] = val_list[idx].clone()
-                # Here we assume a 1D or ND tensor with batch dimension = 0
-                item[key] = val_list[idx]
-        return item
-
-    @staticmethod
-    def _put_batch_item(batch_dict: dict[str, list], idx: int, item: dict[str, Any]) -> None:
-        """
-        Place the given 'item' into the 'idx'-th position of each list/tensor in batch_dict.
-        """
-        for key, val_list in batch_dict.items():
-            if key in item:
-                if isinstance(val_list, list):
-                    val_list[idx] = item[key]
-                else:
-                    # If they're Tensors, we do an assignment:
-                    # val_list[idx] = item[key]
-                    val_list[idx] = item[key]
-            else:
-                # If 'item' does not have this key, we skip or fill with default
-                pass
-
-
 class RayPPOTrainer(object):
     """
     Note that this trainer runs on the driver process on a single CPU/GPU node.
@@ -525,6 +406,8 @@ class RayPPOTrainer(object):
                                          return_raw_chat=self.config.data.get('return_raw_chat', False),
                                          truncation=self.config.data.get('truncation', 'error'),
                                          filter_overlong_prompts=self.config.data.filter_overlong_prompts)
+        self.multiturn_prompt_manager = MultiTurnPromptManager()
+
         assert self.train_dataset.truncation == self.config.data.get(
             'truncation', 'error'
         ), f'dataset truncation {self.train_dataset.truncation} must be the same as config {self.config.data.get("truncation", "error")}'
@@ -543,12 +426,6 @@ class RayPPOTrainer(object):
             drop_last=True,
             collate_fn=collate_fn,
             sampler=sampler)
-
-        # with open("tmp1.pkl", "wb") as f:
-        #     for batch_idx, batch_dict in enumerate(self.train_dataloader):
-        #         import pickle
-        #         pickle.dump(batch_dict, f)
-        #         exit()
 
         self.val_dataset = RLHFDataset(parquet_files=self.config.data.val_files,
                                        tokenizer=self.tokenizer,
@@ -935,8 +812,8 @@ class RayPPOTrainer(object):
                 metrics = {}
 
                 # NOTE(yuxiang): replace a subset of prompts with newly generated multiturn prompts
-                # and postpone the replaced prompts to later batches
-                batch_dict = self.multiturn_prompt_manager.replace_prompts(batch_dict)
+                # and delay their generation to next steps. This is a no-op for non-multiturn prompts.
+                self.multiturn_prompt_manager.replace_prompts_inplace(batch_dict)
 
                 batch: DataProto = DataProto.from_single_dict(batch_dict)
                 num_substep_prompt_cumulation += 1
@@ -960,9 +837,6 @@ class RayPPOTrainer(object):
                     # generate a batch
                     with _timer('gen', timing_raw):
                         gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
-                    
-                    # XXX(yuxiang): implement the multiturn enqueue logic here
-                    # self.multiturn_prompt_manager.update_multiturn_prompts(...)
 
                     if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
                         with _timer('gen_max', timing_raw):
@@ -985,6 +859,43 @@ class RayPPOTrainer(object):
                     # repeat to align with repeated responses in rollout
                     batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
                     batch = batch.union(gen_batch_output)
+
+                    # NOTE(yuxiang): the multiturn enqueue logic
+                    with _timer("multiturn_preprocess", timing_raw):
+                        data_indices: list[int] = batch.non_tensor_batch["data_index"]
+                        responses: torch.Tensor = batch.batch["responses"]
+                        for i, data_index in enumerate(data_indices):
+                            if "remaining_prompt" not in batch.non_tensor_batch:
+                                continue
+
+                            remaining_prompt = batch.non_tensor_batch["remaining_prompt"][i]
+                            if len(remaining_prompt) <= 0:
+                                continue
+                            # XXX: inefficient. decoding will happen again during reward_fn
+                            # XXX: strip away <thinking>
+                            response_text = self.tokenizer.decode(
+                                responses[i], skip_special_tokens=True
+                            )
+                            raw_prompt = batch.non_tensor_batch["raw_prompt"][i]
+                            new_data = self.train_dataset.try_create_multiturn_data(
+                                data_index,
+                                response_text,
+                                raw_prompt,
+                                remaining_prompt,
+                            )
+                            try:
+                                new_processed_data = self.train_dataset.process_row(data_index, new_data)
+                            except NotImplementedError as e:
+                                # We skip examples that exceed the maximum sequence length
+                                pprint(f"Exception in processing multiturn prompts (likely seq_len): {str(e)}")
+                                continue
+                            # XXX: now appending all responses for the same prompt. this can lead to exponential
+                            # growth in the number of prompts.
+                            self.multiturn_prompt_manager.update_multiturn_prompts([new_processed_data])
+                            # Currently, we just do a dumb way to add at most one multi-turn prompt per step
+                            break
+                    # Print the queue status
+                    pprint(self.multiturn_prompt_manager.queue_status())
 
                     # move reward calculaiton in sub-steps
                     with _timer("reward", timing_raw):

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -14,10 +14,11 @@
 
 from omegaconf import ListConfig
 import os
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Any
 import copy
 import pandas as pd
-from collections import defaultdict
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
 
 import torch
 import numpy as np
@@ -43,7 +44,9 @@ def collate_fn(data_list: list[dict]) -> dict:
         tensors[key] = torch.stack(val, dim=0)
 
     for key, val in non_tensors.items():
-        non_tensors[key] = np.array(val, dtype=object)
+        obj_array = np.empty(len(val), dtype=object)
+        obj_array[:] = val
+        non_tensors[key] = obj_array
 
     return {**tensors, **non_tensors}
 
@@ -121,6 +124,7 @@ class RLHFDataset(Dataset):
         for i, parquet_file in enumerate(parquet_files):
             self.parquet_files[i] = copy_to_local(src=parquet_file, cache_dir=self.cache_dir)
 
+
     def _read_files_and_tokenize(self):
         dataframes = []
         for parquet_file in self.parquet_files:
@@ -136,6 +140,7 @@ class RLHFDataset(Dataset):
             tokenizer = self.tokenizer
             prompt_key = self.prompt_key
             self.dataframe = self.dataframe[self.dataframe.apply(lambda doc: len(
+                # XXX: consider multiturn
                 tokenizer.apply_chat_template(doc[prompt_key], add_generation_prompt=True)) <= self.max_prompt_length,
                                                                  axis=1)]
 
@@ -150,6 +155,47 @@ class RLHFDataset(Dataset):
         else:
             print(r'old dataloader ckpt file is used, please train from scratch for better ckpt performance')
 
+
+    @staticmethod
+    def get_actual_userturn_index(messages: list[dict]) -> int:
+        """
+        Returns the index of the first message in the last contiguous block of user messages.
+        If the last message is not a user message, returns -1.
+
+        In a multi-turn conversation, a user may send multiple consecutive messages
+        (e.g. user1, assistant, user2, user3). The function returns the index of the
+        first message of the last contiguous block of user messages (user2 in the example).
+        """
+        assert len(messages) > 0, "Messages should not be empty"
+        assert messages[-1]["role"] == "user", "Last message should be a user message"
+
+        # Search backward to find the last user message
+        i = len(messages) - 1
+        while i > 0 and messages[i - 1]["role"] == "user":
+            i -= 1
+        return i
+
+    def try_create_multiturn_data(
+        self,
+        data_index: int,
+        response: str,
+        raw_prompt: list[dict] | np.ndarray,
+        remaining_prompt: list[dict] | np.ndarray,
+    ) -> dict:
+        """
+        If adding the response won't cause the dialogs to finish, we form a new dialog.
+        """
+        assert len(remaining_prompt) > 0, "Remaining prompt should not be empty"
+        if isinstance(raw_prompt, np.ndarray):
+            raw_prompt = raw_prompt.tolist()
+        if isinstance(remaining_prompt, np.ndarray):
+            remaining_prompt = remaining_prompt.tolist()
+        raw_data = self.dataframe.iloc[data_index].to_dict()
+        new_message = dict(role="assistant", content=response)
+        new_messages = raw_prompt + [new_message] + remaining_prompt
+        raw_data[self.prompt_key] = np.array(new_messages, dtype=object)
+        return raw_data
+
     def __len__(self):
         return len(self.dataframe)
 
@@ -158,10 +204,20 @@ class RLHFDataset(Dataset):
         Note that we also return the raw_input_ids so that it can be combined with other chat template
         """
         row_dict: dict = self.dataframe.iloc[item].to_dict()
+        return self.process_row(item, row_dict)
 
+    def process_row(self, index: int, row_dict: dict) -> dict:
+        # Let's store the data index to help multiturn construction
+        row_dict["data_index"] = index
         chat = row_dict.pop(self.prompt_key)
+        if isinstance(chat, np.ndarray):
+            chat = chat.tolist()
+        actual_userturn_index = self.get_actual_userturn_index(chat)
+        # Remaining multiturn chat
+        remaining_chat = chat[actual_userturn_index + 1 :]
+        actual_chat = chat[: actual_userturn_index + 1]
 
-        prompt_with_chat_template = self.tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=False)
+        prompt_with_chat_template = self.tokenizer.apply_chat_template(actual_chat, add_generation_prompt=True, tokenize=False)
 
         is_multi_modal = self.image_key in row_dict
         if is_multi_modal:  # expand image token
@@ -214,7 +270,8 @@ class RLHFDataset(Dataset):
 
         # encode prompts without chat template
         if self.return_raw_chat:
-            row_dict['raw_prompt'] = chat.tolist()
+            row_dict['remaining_prompt'] = remaining_chat
+            row_dict['raw_prompt'] = actual_chat
 
         # add index for each prompt
         index = row_dict.get("extra_info", {}).get("index", 0)
@@ -230,3 +287,120 @@ class RLHFDataset(Dataset):
                 del state['dataframe']
             return state
         return self.__dict__.copy()
+
+
+BatchDictType = dict[str, list | torch.Tensor]
+
+
+@dataclass
+class MultiTurnPromptManager:
+    """
+    Maintains:
+        1) A queue of multi-turn prompts that still need to be continued in future batches.
+        2) A cache of single-turn prompts that can be re-used for partially filling the batch.
+    """
+
+    # For incomplete multi-turn prompts from previous steps
+    multiturn_queue: deque[dict] = field(default_factory=deque)
+    # For storing single-turn prompts that have been replaced in prior steps
+    singleturn_cache: deque[dict] = field(default_factory=deque)
+    mandatory_batch_key: str = "input_ids"
+
+    def replace_prompts_inplace(self, batch_dict: BatchDictType) -> None:
+        """
+        1) If we have N multi-turn prompts in the queue, then we replace the LAST min(N, batch_size)
+           items in `batch_dict` with the first min(N, batch_size) items from `multiturn_queue`.
+           - Also, we take those replaced batch items and store them in `singleturn_cache`.
+        2) For the remaining front of the batch, we replace up to that many from `singleturn_cache`.
+           - Again, replaced original items are stored back into `singleturn_cache`.
+        3) Return the modified `batch_dict`.
+
+        NOTE: This assumes `batch_dict` has lists or tensors of the same length (batch_size).
+        """
+
+        batch_size = len(batch_dict[self.mandatory_batch_key])
+        # --------------
+        # Step 1: Replace the FIRST K = min(len(multiturn_queue), batch_size) items with multi-turn prompts
+        # --------------
+
+        K = min(len(self.multiturn_queue), batch_size)
+
+        # Prepare for step 2
+        remaining_replacements = batch_size - K
+        L = min(len(self.singleturn_cache), remaining_replacements)
+
+        # We'll operate on indices from (batch_size - K) to (batch_size-1)
+        for idx in range(K):
+            # Pop an item from multi-turn queue
+            multiturn_item = self.multiturn_queue.popleft()
+
+            # Save original batch item to single-turn cache
+            original_item = self._extract_batch_item(batch_dict, idx)
+            # breakpoint()
+            self.singleturn_cache.append(original_item)
+
+            # Insert the multi-turn item into the batch
+            self._put_batch_item(batch_dict, idx, multiturn_item)
+
+        # --------------
+        # Step 2: For the NEXT L items, try replacing them from singleturn_cache
+        # --------------
+
+        # Replace the FIRST L items in the batch
+        for idx in range(K, K + L):
+            singleturn_item = self.singleturn_cache.popleft()
+
+            # Save original batch item to single-turn cache
+            original_item = self._extract_batch_item(batch_dict, idx)
+            self.singleturn_cache.append(original_item)
+
+            # Insert the single-turn item into the batch
+            self._put_batch_item(batch_dict, idx, singleturn_item)
+
+
+    def update_multiturn_prompts(self, new_prompts: list[dict[str, Any]]) -> None:
+        """
+        Append new incomplete multi-turn prompts to the queue for use in future batches.
+        Typically called after generation steps when we identify incomplete dialogues.
+        """
+        for prompt in new_prompts:
+            self.multiturn_queue.append(prompt)
+
+    @staticmethod
+    def _extract_batch_item(batch_dict: BatchDictType, idx: int) -> dict[str, Any]:
+        """
+        Take a snapshot of the 'idx'-th item from each list/tensor in batch_dict.
+        Return it as a dictionary that can be re-injected later.
+        """
+        return {key: val_list[idx] for key, val_list in batch_dict.items()}
+
+    @staticmethod
+    def _put_batch_item(
+        batch_dict: BatchDictType, idx: int, item: dict[str, Any]
+    ) -> None:
+        """
+        Place the given 'item' into the 'idx'-th position of each list/tensor in batch_dict.
+        """
+        for key in batch_dict.keys():
+            if isinstance(batch_dict[key], torch.Tensor):
+                # Rebuild the entire tensor
+                # Otherwise, the extracted batch item may be affected by the change
+                # as that's just a view of the original tensor.
+                old_shape = batch_dict[key].shape  # type: ignore
+                new_tensor = torch.stack(
+                    [
+                        item[key] if i == idx else batch_dict[key][i]
+                        for i in range(old_shape[0])
+                    ]
+                )
+                assert new_tensor.shape == old_shape
+                batch_dict[key] = new_tensor
+            else:
+                # Replace the list item
+                batch_dict[key][idx] = item[key]
+
+    def queue_status(self) -> str:
+        """
+        Return the number of items in the multiturn_queue and singleturn_cache.
+        """
+        return f"Multiturn queue: {len(self.multiturn_queue)}, Singleturn cache: {len(self.singleturn_cache)}"


### PR DESCRIPTION
Replace single-turn prompts with newly generated multiturn prompts in each batch. Try:

```bash
$ python tests/verl/utils/dataset/test_multiturn.py

Saving mock data to /tmp/tmpea8d4s00.parquet
dataset len: 1
OLD PROMPT:
system
You are Qwen, created by Alibaba Cloud. You are a helpful assistant.
user
What are you doing?
assistant

NEW PROMPT:
system
You are Qwen, created by Alibaba Cloud. You are a helpful assistant.
user
What are you doing?
assistant
1 or 2
user
Any luck?
assistant
```